### PR TITLE
Sort pinned documentation alphabetically

### DIFF
--- a/src/App.elm
+++ b/src/App.elm
@@ -199,7 +199,7 @@ update msg model =
 
         PinDoc rest (Ok doc) ->
             { model
-                | pinnedDocs = model.pinnedDocs ++ [ doc ]
+                | pinnedDocs = List.sortBy .packageName <| doc :: model.pinnedDocs
                 , searchIndex =
                     buildSearchIndex
                         model.searchIndex

--- a/src/Views.elm
+++ b/src/Views.elm
@@ -28,7 +28,6 @@ view model =
                 [ input
                     [ class "search-input"
                     , onInput Search
-                    , value model.searchText
                     , placeholder "Search..."
                     , id "search-input"
                     , onFocus (SetSearchFocused True)
@@ -297,7 +296,6 @@ viewNavItem model i navItem =
                 ]
                 [ input
                     [ class "search-package-input"
-                    , value model.searchPackageText
                     , onInput SearchPackage
                     , placeholder "Search Package..."
                     , id "package-search-input"


### PR DESCRIPTION
Hello @jackysee,

I found it hard to find the correct documentation package, so I added alphabetic sorting to the pinned packages.

Also if typing fast, the caret in the search field was moving around. I removed rendering the search values with elm.